### PR TITLE
Fix redundant type conversion

### DIFF
--- a/pike/templates/server.go.tmplt
+++ b/pike/templates/server.go.tmplt
@@ -37,7 +37,7 @@ func LoadConfig() ServerConfig {
 	}
 
 	config := ServerConfig{}
-	err = yaml.Unmarshal([]byte(content), &config)
+	err = yaml.Unmarshal(content, &config)
 	if err != nil {
 		log.Fatalf("Error parsing config: %v", err)
 	}


### PR DESCRIPTION
[ioutil.ReadFile](https://pkg.go.dev/io/ioutil#ReadFile) return `[]byte`